### PR TITLE
use a global IronMeta instance

### DIFF
--- a/iron-validatable-behavior.html
+++ b/iron-validatable-behavior.html
@@ -12,7 +12,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-meta/iron-meta.html">
 
 <script>
+  /**
+   * Singleton IronMeta instance.
+   */
   Polymer.IronValidatableBehaviorMeta = null;
+
   /**
    * `Use Polymer.IronValidatableBehavior` to implement an element that validates user input.
    * Use the related `Polymer.IronValidatorBehavior` to add custom validation logic to an iron-input.

--- a/iron-validatable-behavior.html
+++ b/iron-validatable-behavior.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-meta/iron-meta.html">
 
 <script>
-
+  Polymer.IronValidatableBehaviorMeta = null;
   /**
    * `Use Polymer.IronValidatableBehavior` to implement an element that validates user input.
    * Use the related `Polymer.IronValidatorBehavior` to add custom validation logic to an iron-input.
@@ -42,14 +42,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     properties: {
 
       /**
-       * Namespace for this validator.
-       */
-      validatorType: {
-        type: String,
-        value: 'validator'
-      },
-
-      /**
        * Name of the validator to use.
        */
       validator: {
@@ -66,22 +58,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         value: false
       },
 
+      /**
+       * This property is deprecated and should not be used. Use the global
+       * validator meta singleton, `Polymer.IronValidatableBehaviorMeta` instead.
+       */
       _validatorMeta: {
         type: Object
-      }
+      },
 
+      /**
+       * Namespace for this validator. This property is deprecated and should
+       * not be used. For all intents and purposes, please consider it a
+       * read-only, config-time property.
+       */
+      validatorType: {
+        type: String,
+        value: 'validator'
+      },
+
+      _validator: {
+        computed: '__computeValidator(validator)'
+      }
     },
 
     observers: [
       '_invalidChanged(invalid)'
     ],
 
-    get _validator() {
-      return this._validatorMeta && this._validatorMeta.byKey(this.validator);
-    },
-
-    ready: function() {
-      this._validatorMeta = new Polymer.IronMeta({type: this.validatorType});
+    registered: function() {
+      Polymer.IronValidatableBehaviorMeta = new Polymer.IronMeta({type: 'validator'});
     },
 
     _invalidChanged: function() {
@@ -128,6 +133,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return this._validator.validate(value);
       }
       return true;
+    },
+
+    __computeValidator: function() {
+      return Polymer.IronValidatableBehaviorMeta &&
+          Polymer.IronValidatableBehaviorMeta.byKey(this.validator);
     }
   };
 

--- a/test/cats-only.html
+++ b/test/cats-only.html
@@ -1,0 +1,30 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-validator-behavior/iron-validator-behavior.html">
+
+<script>
+
+  Polymer({
+
+    is: 'cats-only',
+
+    behaviors: [
+      Polymer.IronValidatorBehavior
+    ],
+
+    validate: function(value) {
+      return value === 'cats';
+    }
+
+  });
+
+</script>

--- a/test/dogs-only.html
+++ b/test/dogs-only.html
@@ -1,0 +1,30 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-validator-behavior/iron-validator-behavior.html">
+
+<script>
+
+  Polymer({
+
+    is: 'dogs-only',
+
+    behaviors: [
+      Polymer.IronValidatorBehavior
+    ],
+
+    validate: function(value) {
+      return value === 'dogs';
+    }
+
+  });
+
+</script>

--- a/test/iron-validatable-behavior.html
+++ b/test/iron-validatable-behavior.html
@@ -24,12 +24,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="test-validatable.html">
+  <link rel="import" href="cats-only.html">
+  <link rel="import" href="dogs-only.html">
 
 </head>
 <body>
 
   <test-fixture id="basic">
     <template>
+      <test-validatable></test-validatable>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="validators">
+    <template>
+      <cats-only></cats-only>
+      <dogs-only></dogs-only>
       <test-validatable></test-validatable>
     </template>
   </test-fixture>
@@ -50,6 +60,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var node = fixture('basic');
         var valid = node.validate();
         assert.isTrue(valid);
+      });
+
+      test('changing the validator works', function() {
+        var node = fixture('validators');
+        var input = node[2];
+
+        // Initially there's no validator, so everything is valid.
+        assert.isTrue(input.validate(''));
+        assert.isTrue(input.validate('cats'));
+
+        // Only valid if the value is 'cats'.
+        input.validator = 'cats-only';
+        assert.isFalse(input.validate('ca'));
+        assert.isTrue(input.validate('cats'));
+
+        // Only valid if the value is 'dogs'.
+        input.validator = 'dogs-only';
+        assert.isFalse(input.validate('cats'));
+        assert.isTrue(input.validate('dogs'));
       });
 
     });


### PR DESCRIPTION
Use a singleton IronMeta instance instead of creating one for each element.

I've done a global search, and `validatorType` was never used. Also, it didn't have an observer and was only used in `ready`, so it's unlikely it ever worked correctly (I think it was intended to be a config time property, before we knew how to document private properties). Similarly for the `_validatorMeta` (which already looked private-y). I've added notes to them not to be used.

I've also cached the `_validator` in a computed property, rather than a getter, since the getter gets called in `validate()`, which could be on every key stroke (for auto-validating inputs). I added a unit test for this.

Performance improvement:
<img width="395" alt="screen shot 2016-04-21 at 5 33 00 pm" src="https://cloud.githubusercontent.com/assets/1369170/14728687/e97fbe2a-07eb-11e6-959f-382c7291d8d8.png">

I ran `tattoo` on this branch, and these are the results. Both failures are unrelated to this PR:

```
Tests for: repos/polymer status: FAILED
Tests for: repos/carbon-storage status: FAILED
82 / 84 tests passed. 23 skipped.
```
