### PR TITLE
Feature/multiple validators

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,10 @@
     "paper-styles": "PolymerElements/paper-styles#^1.0.4",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-validator-behavior": "https://github.com/tlouisse/iron-validator-behavior.git#feature/multipleValidators",
+    "paper-input": "https://github.com/tlouisse/paper-input.git#feature/multipleValidators",
     "iron-input": "https://github.com/tlouisse/iron-input.git#feature/multipleValidators",
+    "paper-dialog": "PolymerElements/paper-dialog#^1.0.0",
+    "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "paper-styles": "PolymerElements/paper-styles#^1.0.4",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-validator-behavior": "PolymerElements/iron-validator-behavior#^1.0.0",
+    "iron-validator-behavior": "https://github.com/tlouisse/iron-validator-behavior.git",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"

--- a/bower.json
+++ b/bower.json
@@ -25,9 +25,13 @@
   "devDependencies": {
     "paper-styles": "PolymerElements/paper-styles#^1.0.4",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-validator-behavior": "https://github.com/tlouisse/iron-validator-behavior.git",
+    "iron-validator-behavior": "https://github.com/tlouisse/iron-validator-behavior.git#feature/multipleValidators",
+    "iron-input": "https://github.com/tlouisse/iron-input.git#feature/multipleValidators",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+  },
+  "resolutions": {
+    "iron-validatable-behavior": "feature/multipleValidators"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -35,6 +35,9 @@
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   },
   "resolutions": {
+    "paper-input": "feature/multipleValidators",
+    "iron-validator-behavior": "feature/multipleValidators",
+    "iron-input": "feature/multipleValidators",
     "iron-validatable-behavior": "feature/multipleValidators"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -20,6 +20,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <link rel="import" href="../../paper-styles/demo-pages.html">
+
+  <link rel="import" href="../../iron-validator-behavior/iron-native-validator.html">
+
   <link rel="import" href="validators/cats-only.html">
   <link rel="import" href="validators/no-cats.html">
   <link rel="import" href="validators/no-catfishes.html">
@@ -44,11 +47,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <template is="dom-bind">
 
-    <cats-only></cats-only>
-    <no-catfishes for="customCatfish" message="Custom catfish message"></no-catfishes>
 
     <section>
 
+      <cats-only></cats-only>
       <p>
         only type <code>cats</code>:<br/>
 
@@ -58,6 +60,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <span class="invalid" hidden$="[[!invalid.a]]">invalid</span>
       </p>
 
+
+      <no-catfishes for="customCatfish" message="Custom catfish message"></no-catfishes>
       <p>
         no <code>cat(fishes)</code>:<br/>
 
@@ -65,6 +69,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <br/>
         <span class="valid" hidden$="[[invalid.b]]">valid</span>
         <template is="dom-repeat" items="[[errors]]">
+          <div class="invalid">[[item.priority]]: [[item.message]]</div>
+        </template>
+
+      </p>
+
+      <iron-native-validator validator-name="required" message="Please fill in"></iron-native-validator>
+      <p>
+        no <code>cat(s)</code> and required:<br/>
+
+        <input id="customAndNative"  is="validatable-input" invalid="{{invalid.c}}" validator="required no-cats" required errors="{{errors2}}">
+        <br/>
+        <span class="valid" hidden$="[[invalid.c]]">valid</span>
+        <template is="dom-repeat" items="[[errors2]]">
           <div class="invalid">[[item.priority]]: [[item.message]]</div>
         </template>
 
@@ -78,7 +95,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     var scope = document.querySelector('template[is="dom-bind"]');
-    scope.invalid = { a: false, b: false };
+    scope.invalid = { a: false, b: false, c: false };
   </script>
 
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -20,7 +20,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <link rel="import" href="../../paper-styles/demo-pages.html">
-  <link rel="import" href="cats-only.html">
+  <link rel="import" href="validators/cats-only.html">
+  <link rel="import" href="validators/no-cats.html">
+  <link rel="import" href="validators/no-catfishes.html">
   <link rel="import" href="validatable-input.html">
 
   <style is="custom-style">
@@ -43,16 +45,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template is="dom-bind">
 
     <cats-only></cats-only>
+    <no-cats></no-cats>
+    <no-catfishes></no-catfishes>
 
     <section>
 
       <p>
-        only type <code>cats</code>:
+        only type <code>cats</code>:<br/>
 
-        <input is="validatable-input" invalid="{{invalid}}" validator="cats-only">
+        <input is="validatable-input" invalid="{{invalid.a}}" validator="cats-only">
+        <br/>
+        <span class="valid" hidden$="[[invalid.a]]">valid</span>
+        <span class="invalid" hidden$="[[!invalid.a]]">invalid</span>
+      </p>
 
-        <span class="valid" hidden$="[[invalid]]">valid</span>
-        <span class="invalid" hidden$="[[!invalid]]">invalid</span>
+      <p>
+        no <code>cat(fishes)</code>:<br/>
+
+        <input id="multiple" is="validatable-input" invalid="{{invalid.b}}" validator="no-cats no-catfishes" errors="{{errors}}">
+        <br/>
+        <span class="valid" hidden$="[[invalid.b]]">valid</span>
+        <template is="dom-repeat" items="[[errors]]">
+          <div class="invalid">[[item.priority]]: [[item.message]]</div>
+        </template>
+
       </p>
 
     </section>
@@ -62,9 +78,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </div>
 
   <script>
-
-    document.querySelector('template[is="dom-bind"]').invalid = false;
-
+    var scope = document.querySelector('template[is="dom-bind"]');
+    scope.invalid = { a: false, b: false };
   </script>
 
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -46,7 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <cats-only></cats-only>
     <no-cats></no-cats>
-    <no-catfishes></no-catfishes>
+    <no-catfishes for="customCatfish" message="Custom catfish message"></no-catfishes>
 
     <section>
 
@@ -62,7 +62,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <p>
         no <code>cat(fishes)</code>:<br/>
 
-        <input id="multiple" is="validatable-input" invalid="{{invalid.b}}" validator="no-cats no-catfishes" errors="{{errors}}">
+        <input id="multiple" validatable-id="customCatfish" is="validatable-input" invalid="{{invalid.b}}" validator="no-cats no-catfishes" errors="{{errors}}">
         <br/>
         <span class="valid" hidden$="[[invalid.b]]">valid</span>
         <template is="dom-repeat" items="[[errors]]">

--- a/demo/index.html
+++ b/demo/index.html
@@ -28,7 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="validators/no-catfishes.html">
   <link rel="import" href="validatable-input.html">
 
-  <style is="custom-style">
+  <style is="custom-style" include="paper-styles">
 
     .valid {
       color: var(--google-green-500);

--- a/demo/index.html
+++ b/demo/index.html
@@ -45,7 +45,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template is="dom-bind">
 
     <cats-only></cats-only>
-    <no-cats></no-cats>
     <no-catfishes for="customCatfish" message="Custom catfish message"></no-catfishes>
 
     <section>

--- a/demo/old-vs-new/index.html
+++ b/demo/old-vs-new/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-    <title>tgc-forms Demo</title>
+    <title>Multiple validators - Before and after</title>
     <script src="../../../webcomponentsjs/webcomponents-lite.min.js"></script>
 
     <link rel="stylesheet" href="../../../prism/themes/prism.css">

--- a/demo/old-vs-new/index.html
+++ b/demo/old-vs-new/index.html
@@ -1,0 +1,192 @@
+<!doctype html>
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>tgc-forms Demo</title>
+    <script src="../../../webcomponentsjs/webcomponents-lite.min.js"></script>
+
+    <link rel="stylesheet" href="../../../prism/themes/prism.css">
+
+
+    <link rel="import" href="../../../paper-styles/demo-pages.html">
+
+    <link rel="import" href="no-cats-or-catfishes.html">
+
+    <link rel="import" href="../../../paper-input/paper-input.html">
+    <link rel="import" href="../../../paper-icon-button/paper-icon-button.html">
+    <link rel="import" href="../../../paper-dialog/paper-dialog.html">
+    <link rel="import" href="../../../paper-button/paper-button.html">
+
+    <link rel="import" href="native-validators-config.html">
+
+
+</head>
+<body unresolved>
+
+
+<template is="dom-bind" id="scope">
+
+    <script src="../../../prism/prism.js"></script>
+
+    <style>
+        paper-dialog {
+            width: 976px;
+            margin: auto;
+        }
+    </style>
+
+
+    <native-validators-config></native-validators-config>
+
+    <div style="width:1024px; margin:auto;">
+
+        <form novalidate id="form">
+
+            <h1> Multiple validators </h1>
+
+            <p>
+                Scenario: add an animal with at least two characters, but cats and catfishes are not allowed.
+            </p>
+
+            <h2>Before</h2>
+            <ul>
+                <li>Make custom validator for specific case (new web component that combines logic of no-cats and
+                    no-dogs, see no-cats-or-catfishes.html)
+                </li>
+                <li>Instantiate custom validator</li>
+                <li>Add custom validator to input (add to validator attribute)</li>
+                <li>Add native validators to input (add as attribute)</li>
+                <li>Add custom error message</li>
+                <li>Eventually, keep track of validity state and dynamically change the error message</li>
+            </ul>
+
+            <script>
+
+                window.addEventListener('WebComponentsReady', function () {
+                    var input = document.getElementById('before').$.input;
+                    var validator = document.getElementById('combinedValidator');
+                    var scope = document.getElementById('scope');
+
+                    scope.msg = 'Make sure this field is not empty and contains at least two characters. Cats and catfishes are not allowed.';
+                    input.addEventListener('iron-input-validate', function setErrorMessage() {
+                        if (input.validity.valueMissing) {
+                            scope.msg = 'Please fill in this field';
+                        } else if (input.validity.patternMismatch) {
+                            scope.msg = 'Use at least two characters';
+                            /* Note the custom validator can only be assigned to one input when using it to store state of sub validators. */
+                        } else if (!validator.validState.noCats) {
+                            scope.msg = 'No cat(s) allowed';
+                        } else if (!validator.validState.noCatfishes) {
+                            scope.msg = 'No cat(fish(es)) allowed';
+                        }
+                    });
+                });
+
+            </script>
+
+            <no-cats-or-catfishes id="combinedValidator"></no-cats-or-catfishes>
+
+            <paper-input id="before" label="Your favorite animal (*)" auto-validate
+                           validator="no-cats-or-catfishes" required pattern=".{2,}"
+                           error-message="[[msg]]">
+            </paper-input>
+
+            <paper-button raised onclick="beforeSrc.open()">View sources</paper-button>
+
+            <paper-dialog id="beforeSrc">
+
+                <h3>Before: sources</h3>
+
+                <h4>Javascript</h4>
+                <pre>
+<code class="language-javascript">window.addEventListener('WebComponentsReady', function () {
+    var input = document.getElementById('before').$.input;
+    var validator = document.getElementById('combinedValidator');
+    var scope = document.getElementById('scope');
+
+    scope.msg = 'Make sure this field is not empty and contains at least two characters. Cats and catfishes are not allowed.';
+    input.addEventListener('iron-input-validate', function setErrorMessage() {
+        if (input.validity.valueMissing) {
+            scope.msg = 'Please fill in this field';
+        } else if (input.validity.patternMismatch) {
+            scope.msg = 'Use at least two characters';
+            // Note the custom validator can only be assigned to one input when using it to store state of sub validators.
+        } else if (!validator.validState.noCats) {
+            scope.msg = 'No cat(s) allowed';
+        } else if (!validator.validState.noCatfishes) {
+            scope.msg = 'No cat(fish(es)) allowed';
+        }
+    });
+});</code>
+</pre>
+
+                <h4>HTML</h4>
+
+
+                <pre>
+<code class="language-html">&lt;no-cats-or-catfishes id=&quot;combinedValidator&quot;&gt;&lt;/no-cats-or-catfishes&gt;
+
+&lt;paper-input id=&quot;before&quot; label=&quot;Your favorite animal (*)&quot; auto-validate
+    validator=&quot;no-cats-or-catfishes&quot; required pattern=&quot;.{2,}&quot;
+    error-message=&quot;&#91;&#91;msg&#93;&#93;&quot;&gt;
+&lt;/paper-input&gt;</code>
+</pre>
+
+
+                <h4>External validator</h4>
+
+                <p>See 'no-cats-or-catfishes.html' ...</p>
+
+                <div class="buttons">
+                    <paper-button dialog-confirm autofocus>Close</paper-button>
+                </div>
+            </paper-dialog>
+
+            <h2>After</h2>
+
+            <ul>
+                <li>Add custom validators to input (add to validator attribute)</li>
+                <li>Add native validators to input (add to validator and as attribute)</li>
+            </ul>
+
+            <p>
+                (Note that no-cats has a higher priority than no-catfishes and its error message will therefore take
+                precedence over that of no-catfishes)
+            </p>
+
+            <paper-input id="after" label="Your favorite animal (*)" auto-validate
+                           validator="required pattern no-cats no-catfishes" required pattern=".{2,}">
+            </paper-input>
+
+
+            <paper-button raised onclick="afterSrc.open()">View sources</paper-button>
+
+
+            <paper-dialog id="afterSrc">
+                <h3>After: sources</h3>
+
+                <h4>HTML</h4>
+                <pre><code class="language-html">&lt;paper-input id=&quot;after&quot; label=&quot;Your favorite animal (*)&quot; auto-validate
+    validator=&quot;required pattern no-cats no-catfishes&quot; required pattern=&quot;.{2,}&quot;&gt;
+&lt;/paper-input&gt;</code>
+</pre>
+
+                <h4>Native messages configuration</h4>
+
+                <p>See 'native-validators-config.html'(this configuration is needed once on a global level) ...</p>
+
+                <div class="buttons">
+                    <paper-button dialog-confirm autofocus>Close</paper-button>
+                </div>
+
+            </paper-dialog>
+        </form>
+
+    </div>
+
+</template>
+
+</body>
+</html>

--- a/demo/old-vs-new/native-validators-config.html
+++ b/demo/old-vs-new/native-validators-config.html
@@ -1,0 +1,21 @@
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-native-validator.html">
+
+<dom-module id="native-validators-config">
+    <template>
+        <!--Register all native validators with a custom message-->
+        <iron-native-validator validator-name="required" message="Please fill in this field" id="instance"></iron-native-validator>
+        <iron-native-validator validator-name="max" message="less"></iron-native-validator>
+        <iron-native-validator validator-name="min" message="more"></iron-native-validator>
+        <iron-native-validator validator-name="step" message="step"></iron-native-validator>
+        <iron-native-validator validator-name="maxlength" message="shorter"></iron-native-validator>
+        <iron-native-validator validator-name="minlength" message="longer"></iron-native-validator>
+        <iron-native-validator validator-name="pattern" message="either regex or input invalid"></iron-native-validator>
+        <iron-native-validator validator-name="emailtype" message="no valid e-mail"></iron-native-validator>
+        <iron-native-validator validator-name="urltype" message="no valid url"></iron-native-validator>
+    </template>
+
+    <script>
+        Polymer({is: 'native-validators-config'});
+    </script>
+</dom-module>

--- a/demo/old-vs-new/no-cats-or-catfishes.html
+++ b/demo/old-vs-new/no-cats-or-catfishes.html
@@ -1,0 +1,63 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
+<link rel="import" href="../validators/no-cats.html">
+<link rel="import" href="../validators/no-catfishes.html">
+
+
+<dom-module id="no-cats-or-catfishes">
+
+    <script>
+
+        (function () {
+
+            var noCatsValidator;
+            var noCatFishesValidator;
+
+            Polymer({
+
+                is: 'no-cats-or-catfishes',
+
+                properties: {
+                    validState: {
+                        type: Object,
+                        value: function () {
+                            return {
+                                'noCats': true,
+                                'noCatfishes': true
+                            }
+                        }
+                    }
+                },
+
+                ready: function () {
+                    noCatsValidator = document.createElement('no-cats');
+                    noCatFishesValidator = document.createElement('no-catfishes');
+                },
+
+                behaviors: [
+                    Polymer.IronValidatorBehavior
+                ],
+
+                validate: function (value) {
+                    this.validState.noCats = noCatsValidator.validate(value);
+                    this.validState.noCatfishes = noCatFishesValidator.validate(value);
+                    return noCatsValidator.validate(value) && noCatFishesValidator.validate(value);
+                }
+
+            });
+
+        }());
+
+    </script>
+
+</dom-module>

--- a/demo/validators/cats-only.html
+++ b/demo/validators/cats-only.html
@@ -8,8 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../iron-validator-behavior/iron-validator-behavior.html">
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
 
 <script>
 

--- a/demo/validators/no-catfishes.html
+++ b/demo/validators/no-catfishes.html
@@ -1,0 +1,37 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
+
+<script>
+
+    Polymer({
+
+        is: 'no-catfishes',
+
+        properties: {
+            message: {
+                type: String,
+                value: 'No cat(fish(es)) allowed'
+            }
+        },
+
+        behaviors: [
+            Polymer.IronValidatorBehavior
+        ],
+
+        validate: function (value) {
+            return !value.match(/cat(fish|fishes)?$/);
+        }
+
+    });
+
+</script>

--- a/demo/validators/no-cats.html
+++ b/demo/validators/no-cats.html
@@ -1,0 +1,37 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
+
+<script>
+
+    Polymer({
+
+        is: 'no-cats',
+
+        properties: {
+            message: {
+                type: String,
+                value: 'No cat(s) allowed'
+            }
+        },
+
+        behaviors: [
+            Polymer.IronValidatorBehavior
+        ],
+
+        validate: function (value) {
+            return !value.match(/cats?$/);
+        }
+
+    });
+
+</script>

--- a/iron-validatable-behavior.html
+++ b/iron-validatable-behavior.html
@@ -205,6 +205,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 else if (meta && meta.byKey(v)) {
                     result[v] = meta.byKey(v);
                 }
+                // No instance at all, create one
+                else if (!meta || !meta.byKey(v)) {
+                    result[v] = document.createElement(v);
+                }
             });
 
             return result;

--- a/iron-validatable-behavior.html
+++ b/iron-validatable-behavior.html
@@ -12,138 +12,190 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-meta/iron-meta.html">
 
 <script>
-  /**
-   * Singleton IronMeta instance.
-   */
-  Polymer.IronValidatableBehaviorMeta = null;
-
-  /**
-   * `Use Polymer.IronValidatableBehavior` to implement an element that validates user input.
-   * Use the related `Polymer.IronValidatorBehavior` to add custom validation logic to an iron-input.
-   *
-   * By default, an `<iron-form>` element validates its fields when the user presses the submit button.
-   * To validate a form imperatively, call the form's `validate()` method, which in turn will
-   * call `validate()` on all its children. By using `Polymer.IronValidatableBehavior`, your
-   * custom element will get a public `validate()`, which
-   * will return the validity of the element, and a corresponding `invalid` attribute,
-   * which can be used for styling.
-   *
-   * To implement the custom validation logic of your element, you must override
-   * the protected `_getValidity()` method of this behaviour, rather than `validate()`.
-   * See [this](https://github.com/PolymerElements/iron-form/blob/master/demo/simple-element.html)
-   * for an example.
-   *
-   * ### Accessibility
-   *
-   * Changing the `invalid` property, either manually or by calling `validate()` will update the
-   * `aria-invalid` attribute.
-   *
-   * @demo demo/index.html
-   * @polymerBehavior
-   */
-  Polymer.IronValidatableBehavior = {
-
-    properties: {
-
-      /**
-       * Name of the validator to use.
-       */
-      validator: {
-        type: String
-      },
-
-      /**
-       * True if the last call to `validate` is invalid.
-       */
-      invalid: {
-        notify: true,
-        reflectToAttribute: true,
-        type: Boolean,
-        value: false
-      },
-
-      /**
-       * This property is deprecated and should not be used. Use the global
-       * validator meta singleton, `Polymer.IronValidatableBehaviorMeta` instead.
-       */
-      _validatorMeta: {
-        type: Object
-      },
-
-      /**
-       * Namespace for this validator. This property is deprecated and should
-       * not be used. For all intents and purposes, please consider it a
-       * read-only, config-time property.
-       */
-      validatorType: {
-        type: String,
-        value: 'validator'
-      },
-
-      _validator: {
-        type: Object,
-        computed: '__computeValidator(validator)'
-      }
-    },
-
-    observers: [
-      '_invalidChanged(invalid)'
-    ],
-
-    registered: function() {
-      Polymer.IronValidatableBehaviorMeta = new Polymer.IronMeta({type: 'validator'});
-    },
-
-    _invalidChanged: function() {
-      if (this.invalid) {
-        this.setAttribute('aria-invalid', 'true');
-      } else {
-        this.removeAttribute('aria-invalid');
-      }
-    },
-
     /**
-     * @return {boolean} True if the validator `validator` exists.
+     * Singleton IronMeta instance.
      */
-    hasValidator: function() {
-      return this._validator != null;
-    },
+    Polymer.IronValidatableBehaviorMeta = null;
 
     /**
-     * Returns true if the `value` is valid, and updates `invalid`. If you want
-     * your element to have custom validation logic, do not override this method;
-     * override `_getValidity(value)` instead.
-
-     * @param {Object} value The value to be validated. By default, it is passed
-     * to the validator's `validate()` function, if a validator is set.
-     * @return {boolean} True if `value` is valid.
-     */
-    validate: function(value) {
-      this.invalid = !this._getValidity(value);
-      return !this.invalid;
-    },
-
-    /**
-     * Returns true if `value` is valid.  By default, it is passed
-     * to the validator's `validate()` function, if a validator is set. You
-     * should override this method if you want to implement custom validity
-     * logic for your element.
+     * `Use Polymer.IronValidatableBehavior` to implement an element that validates user input.
+     * Use the related `Polymer.IronValidatorBehavior` to add custom validation logic to an iron-input.
      *
-     * @param {Object} value The value to be validated.
-     * @return {boolean} True if `value` is valid.
+     * By default, an `<iron-form>` element validates its fields when the user presses the submit button.
+     * To validate a form imperatively, call the form's `validate()` method, which in turn will
+     * call `validate()` on all its children. By using `Polymer.IronValidatableBehavior`, your
+     * custom element will get a public `validate()`, which
+     * will return the validity of the element, and a corresponding `invalid` attribute,
+     * which can be used for styling.
+     *
+     * To implement the custom validation logic of your element, you must override
+     * the protected `_getValidity()` method of this behaviour, rather than `validate()`.
+     * See [this](https://github.com/PolymerElements/iron-form/blob/master/demo/simple-element.html)
+     * for an example.
+     *
+     * ### Accessibility
+     *
+     * Changing the `invalid` property, either manually or by calling `validate()` will update the
+     * `aria-invalid` attribute.
+     *
+     * @demo demo/index.html
+     * @polymerBehavior
      */
+    Polymer.IronValidatableBehavior = {
 
-    _getValidity: function(value) {
-      if (this.hasValidator()) {
-        return this._validator.validate(value);
-      }
-      return true;
-    },
+        properties: {
 
-    __computeValidator: function() {
-      return Polymer.IronValidatableBehaviorMeta &&
-          Polymer.IronValidatableBehaviorMeta.byKey(this.validator);
-    }
-  };
+            /**
+             * Name of the validator(s) to use.
+             * Accepts a list of validators, separated by spaces.
+             * Note that the order of the validators determines the priority of the error messages. See 'error'
+             */
+            validator: {
+                type: String
+            },
+
+            /**
+             * True if the last call to `validate` is invalid.
+             */
+            invalid: {
+                notify: true,
+                reflectToAttribute: true,
+                type: Boolean,
+                value: false
+            },
+
+            /**
+             * This property is deprecated and should not be used. Use the global
+             * validator meta singleton, `Polymer.IronValidatableBehaviorMeta` instead.
+             */
+            _validatorMeta: {
+                type: Object
+            },
+
+            /**
+             * Namespace for this validator. This property is deprecated and should
+             * not be used. For all intents and purposes, please consider it a
+             * read-only, config-time property.
+             */
+            validatorType: {
+                type: String,
+                value: 'validator'
+            },
+
+            _validator: {
+                type: Object,
+                computed: '__computeValidator(validator)'
+            },
+
+            /**
+             * Array holding error objects for the current state of the validatable element.
+             * Each error has the following format:
+             * {Object} error
+             * {string} error.name -- validator name of custom validator instance with IronValidatorBehavior
+             * {string} error.message -- message that is assigned to the validator instance
+             * {number} error.priority -- priority of the error message, based on order supplied in validator property
+             */
+            errors: {
+                type: Array,
+                readOnly: true,
+                notify: true,
+                value: function () {
+                    return [];
+                }
+            }
+
+        },
+
+        observers: [
+            '_invalidChanged(invalid)'
+        ],
+
+        registered: function () {
+            Polymer.IronValidatableBehaviorMeta = new Polymer.IronMeta({type: 'validator'});
+        },
+
+        _invalidChanged: function () {
+            if (this.invalid) {
+                this.setAttribute('aria-invalid', 'true');
+            } else {
+                this.removeAttribute('aria-invalid');
+            }
+        },
+
+        /**
+         * @return {boolean} True if the validator `validator` exists.
+         */
+        hasValidator: function () {
+            return this._validator != null;
+        },
+
+        /**
+         * Returns true if the `value` is valid, and updates `invalid`. If you want
+         * your element to have custom validation logic, do not override this method;
+         * override `_getValidity(value)` instead.
+
+         * @param {Object} value The value to be validated. By default, it is passed
+         * to the validator's `validate()` function, if a validator is set.
+         * @return {boolean} True if `value` is valid.
+         */
+        validate: function (value) {
+            this.invalid = !this._getValidity(value);
+            return !this.invalid;
+        },
+
+        /**
+         * Returns true if `value` is valid.  By default, it is passed
+         * to the validator's `validate()` function, if a validator is set. You
+         * should override this method if you want to implement custom validity
+         * logic for your element.
+         *
+         * @param {Object} value The value to be validated
+         * @return {boolean} True if `value` is valid.
+         */
+        _getValidity: function (value) {
+            this._fillErrorArray(value);
+            return this.errors.length === 0;
+        },
+
+        /**
+         * Fills the errors property with objects as described in errors documentation.
+         * @param {Object} value The value to be validated.
+         */
+        _fillErrorArray: function (value) {
+            var index = 0;
+            this._setErrors([]);
+
+            // Fill error array that is prioritized based on order of arguments in validator attribute
+            for (var v in this._validator) {
+                if (!this._validator[v].validate(value, this)) {
+                    this.push('errors', {
+                        name: this._validator[v].validatorName,
+                        message: this._validator[v].message,
+                        priority: index
+                    });
+                    index++;
+                }
+            }
+        },
+
+        /**
+         * Creates an object with references to the validator instances supplied in validator property.
+         * @return {Object} validators The validators to be executed.
+         */
+        __computeValidator: function () {
+            var result = {};
+            var meta = Polymer.IronValidatableBehaviorMeta;
+            var validators = this.validator.replace(/\s+/g, ' ').split(' ');
+
+            validators.forEach(function (v) {
+                if (meta && meta.byKey(v)) {
+                    result[v] = meta.byKey(v);
+                }
+            });
+
+            return result;
+        }
+
+    };
 
 </script>

--- a/iron-validatable-behavior.html
+++ b/iron-validatable-behavior.html
@@ -52,7 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 /**
                  * Name of the validator(s) to use.
                  * Accepts a list of validators, separated by spaces.
-                 * Note that the order of the validators determines the priority of the error messages. See 'error'
+                 * Note that the order of the validators determines the priority of the error messages.
                  */
                 validator: {
                     type: String

--- a/iron-validatable-behavior.html
+++ b/iron-validatable-behavior.html
@@ -102,6 +102,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 value: function () {
                     return [];
                 }
+            },
+
+            /**
+             * The id used to connect the validator instance implementing IronValidatableBehavior(having a 'for' property)
+             * to the validatable. This is useful for validator instances containing custom messages.
+             */
+            validatableId: {
+                type: String
             }
 
         },
@@ -184,11 +192,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
          */
         __computeValidator: function () {
             var result = {};
+            var suffix = '--' + this.validatableId; // Suffix needed for specific instances of custom validators, overriding the default error message
             var meta = Polymer.IronValidatableBehaviorMeta;
             var validators = this.validator.replace(/\s+/g, ' ').split(' ');
 
             validators.forEach(function (v) {
-                if (meta && meta.byKey(v)) {
+                // Custom instance exists
+                if (meta && meta.byKey(v + suffix)) {
+                    result[v] = meta.byKey(v + suffix);
+                }
+                // Default instance exists
+                else if (meta && meta.byKey(v)) {
                     result[v] = meta.byKey(v);
                 }
             });

--- a/iron-validatable-behavior.html
+++ b/iron-validatable-behavior.html
@@ -12,208 +12,225 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-meta/iron-meta.html">
 
 <script>
-    /**
-     * Singleton IronMeta instance.
-     */
-    Polymer.IronValidatableBehaviorMeta = null;
 
-    /**
-     * `Use Polymer.IronValidatableBehavior` to implement an element that validates user input.
-     * Use the related `Polymer.IronValidatorBehavior` to add custom validation logic to an iron-input.
-     *
-     * By default, an `<iron-form>` element validates its fields when the user presses the submit button.
-     * To validate a form imperatively, call the form's `validate()` method, which in turn will
-     * call `validate()` on all its children. By using `Polymer.IronValidatableBehavior`, your
-     * custom element will get a public `validate()`, which
-     * will return the validity of the element, and a corresponding `invalid` attribute,
-     * which can be used for styling.
-     *
-     * To implement the custom validation logic of your element, you must override
-     * the protected `_getValidity()` method of this behaviour, rather than `validate()`.
-     * See [this](https://github.com/PolymerElements/iron-form/blob/master/demo/simple-element.html)
-     * for an example.
-     *
-     * ### Accessibility
-     *
-     * Changing the `invalid` property, either manually or by calling `validate()` will update the
-     * `aria-invalid` attribute.
-     *
-     * @demo demo/index.html
-     * @polymerBehavior
-     */
-    Polymer.IronValidatableBehavior = {
-
-        properties: {
-
-            /**
-             * Name of the validator(s) to use.
-             * Accepts a list of validators, separated by spaces.
-             * Note that the order of the validators determines the priority of the error messages. See 'error'
-             */
-            validator: {
-                type: String
-            },
-
-            /**
-             * True if the last call to `validate` is invalid.
-             */
-            invalid: {
-                notify: true,
-                reflectToAttribute: true,
-                type: Boolean,
-                value: false
-            },
-
-            /**
-             * This property is deprecated and should not be used. Use the global
-             * validator meta singleton, `Polymer.IronValidatableBehaviorMeta` instead.
-             */
-            _validatorMeta: {
-                type: Object
-            },
-
-            /**
-             * Namespace for this validator. This property is deprecated and should
-             * not be used. For all intents and purposes, please consider it a
-             * read-only, config-time property.
-             */
-            validatorType: {
-                type: String,
-                value: 'validator'
-            },
-
-            _validator: {
-                type: Object,
-                computed: '__computeValidator(validator)'
-            },
-
-            /**
-             * Array holding error objects for the current state of the validatable element.
-             * Each error has the following format:
-             * {Object} error
-             * {string} error.name -- validator name of custom validator instance with IronValidatorBehavior
-             * {string} error.message -- message that is assigned to the validator instance
-             * {number} error.priority -- priority of the error message, based on order supplied in validator property
-             */
-            errors: {
-                type: Array,
-                readOnly: true,
-                notify: true,
-                value: function () {
-                    return [];
-                }
-            },
-
-            /**
-             * The id used to connect the validator instance implementing IronValidatableBehavior(having a 'for' property)
-             * to the validatable. This is useful for validator instances containing custom messages.
-             */
-            validatableId: {
-                type: String
-            }
-
-        },
-
-        observers: [
-            '_invalidChanged(invalid)'
-        ],
-
-        registered: function () {
-            Polymer.IronValidatableBehaviorMeta = new Polymer.IronMeta({type: 'validator'});
-        },
-
-        _invalidChanged: function () {
-            if (this.invalid) {
-                this.setAttribute('aria-invalid', 'true');
-            } else {
-                this.removeAttribute('aria-invalid');
-            }
-        },
+    (function () {
 
         /**
-         * @return {boolean} True if the validator `validator` exists.
+         * Singleton IronMeta instances.
          */
-        hasValidator: function () {
-            return this._validator != null;
-        },
+        var customMeta = null;
+        var nativeMeta = null;
 
         /**
-         * Returns true if the `value` is valid, and updates `invalid`. If you want
-         * your element to have custom validation logic, do not override this method;
-         * override `_getValidity(value)` instead.
-
-         * @param {Object} value The value to be validated. By default, it is passed
-         * to the validator's `validate()` function, if a validator is set.
-         * @return {boolean} True if `value` is valid.
-         */
-        validate: function (value) {
-            this.invalid = !this._getValidity(value);
-            return !this.invalid;
-        },
-
-        /**
-         * Returns true if `value` is valid.  By default, it is passed
-         * to the validator's `validate()` function, if a validator is set. You
-         * should override this method if you want to implement custom validity
-         * logic for your element.
+         * `Use Polymer.IronValidatableBehavior` to implement an element that validates user input.
+         * Use the related `Polymer.IronValidatorBehavior` to add custom validation logic to an iron-input.
          *
-         * @param {Object} value The value to be validated
-         * @return {boolean} True if `value` is valid.
+         * By default, an `<iron-form>` element validates its fields when the user presses the submit button.
+         * To validate a form imperatively, call the form's `validate()` method, which in turn will
+         * call `validate()` on all its children. By using `Polymer.IronValidatableBehavior`, your
+         * custom element will get a public `validate()`, which
+         * will return the validity of the element, and a corresponding `invalid` attribute,
+         * which can be used for styling.
+         *
+         * To implement the custom validation logic of your element, you must override
+         * the protected `_getValidity()` method of this behaviour, rather than `validate()`.
+         * See [this](https://github.com/PolymerElements/iron-form/blob/master/demo/simple-element.html)
+         * for an example.
+         *
+         * ### Accessibility
+         *
+         * Changing the `invalid` property, either manually or by calling `validate()` will update the
+         * `aria-invalid` attribute.
+         *
+         * @demo demo/index.html
+         * @polymerBehavior
          */
-        _getValidity: function (value) {
-            this._fillErrorArray(value);
-            return this.errors.length === 0;
-        },
+        Polymer.IronValidatableBehavior = {
 
-        /**
-         * Fills the errors property with objects as described in errors documentation.
-         * @param {Object} value The value to be validated.
-         */
-        _fillErrorArray: function (value) {
-            var index = 0;
-            this._setErrors([]);
+            properties: {
 
-            // Fill error array that is prioritized based on order of arguments in validator attribute
-            for (var v in this._validator) {
-                if (!this._validator[v].validate(value, this)) {
-                    this.push('errors', {
-                        name: this._validator[v].validatorName,
-                        message: this._validator[v].message,
-                        priority: index
-                    });
-                    index++;
+                /**
+                 * Name of the validator(s) to use.
+                 * Accepts a list of validators, separated by spaces.
+                 * Note that the order of the validators determines the priority of the error messages. See 'error'
+                 */
+                validator: {
+                    type: String
+                },
+
+                /**
+                 * True if the last call to `validate` is invalid.
+                 */
+                invalid: {
+                    notify: true,
+                    reflectToAttribute: true,
+                    type: Boolean,
+                    value: false
+                },
+
+                /**
+                 * This property is deprecated and should not be used. Use the global
+                 * validator meta singleton, `Polymer.IronValidatableBehaviorMeta` instead.
+                 */
+                _validatorMeta: {
+                    type: Object
+                },
+
+                /**
+                 * Namespace for this validator. This property is deprecated and should
+                 * not be used. For all intents and purposes, please consider it a
+                 * read-only, config-time property.
+                 */
+                validatorType: {
+                    type: String,
+                    value: 'validator'
+                },
+
+                _validator: {
+                    type: Object,
+                    computed: '__computeValidator(validator)'
+                },
+
+                /**
+                 * Array holding error objects for the current state of the validatable element.
+                 * Each error has the following format:
+                 * {Object} error
+                 * {string} error.name -- validator name of custom validator instance with IronValidatorBehavior
+                 * {string} error.message -- message that is assigned to the validator instance
+                 * {number} error.priority -- priority of the error message, based on order supplied in validator property
+                 */
+                errors: {
+                    type: Array,
+                    readOnly: true,
+                    notify: true,
+                    value: function () {
+                        return [];
+                    }
+                },
+
+                /**
+                 * The id used to connect the validator instance implementing IronValidatableBehavior(having a 'for' property)
+                 * to the validatable. This is useful for validator instances containing custom messages.
+                 */
+                validatableId: {
+                    type: String,
+                    value: ''
                 }
+
+            },
+
+            observers: [
+                '_invalidChanged(invalid)'
+            ],
+
+            registered: function () {
+                customMeta = new Polymer.IronMeta({type: 'validator'});
+                nativeMeta = new Polymer.IronMeta({type: 'native-validator'});
+            },
+
+            _invalidChanged: function () {
+                if (this.invalid) {
+                    this.setAttribute('aria-invalid', 'true');
+                } else {
+                    this.removeAttribute('aria-invalid');
+                }
+            },
+
+            /**
+             * @return {boolean} True if the validator `validator` exists.
+             */
+            hasValidator: function () {
+                return this._validator != null;
+            },
+
+            /**
+             * Returns true if the `value` is valid, and updates `invalid`. If you want
+             * your element to have custom validation logic, do not override this method;
+             * override `_getValidity(value)` instead.
+
+             * @param {Object} value The value to be validated. By default, it is passed
+             * to the validator's `validate()` function, if a validator is set.
+             * @return {boolean} True if `value` is valid.
+             */
+            validate: function (value) {
+                this.invalid = !this._getValidity(value);
+                return !this.invalid;
+            },
+
+            /**
+             * Returns true if `value` is valid.  By default, it is passed
+             * to the validator's `validate()` function, if a validator is set. You
+             * should override this method if you want to implement custom validity
+             * logic for your element.
+             *
+             * @param {Object} value The value to be validated
+             * @return {boolean} True if `value` is valid.
+             */
+            _getValidity: function (value) {
+                this._fillErrorArray(value);
+                return this.errors.length === 0;
+            },
+
+            /**
+             * Fills the errors property with objects as described in errors documentation.
+             * @param {Object} value The value to be validated.
+             */
+            _fillErrorArray: function (value) {
+                var index = 0;
+                this._setErrors([]);
+
+                // Fill error array that is prioritized based on order of arguments in validator attribute
+                for (var v in this._validator) {
+                    if (!this._validator[v].validate(value, this)) {
+                        this.push('errors', {
+                            name: this._validator[v].validatorName,
+                            message: this._validator[v].message,
+                            priority: index
+                        });
+                        index++;
+                    }
+                }
+            },
+
+            /**
+             * Creates an object with multiple validators.
+             *
+             * @return {Object} validators The validators to be executed.
+             */
+            __computeValidator: function () {
+                var result = {};
+                var suffix = '--' + this.validatableId; // Suffix needed for specific instances of custom validators, overriding the default error message
+                var validators = this.validator.replace(/\s+/g, ' ').split(' ');
+
+                // Gather all meta information from custom and native validators
+                var meta = {custom: customMeta, native: nativeMeta};
+
+                validators.forEach(function (v) {
+                    // Custom validators need to be web components and will therefore always contain a hyphen.
+                    // Native validators (think of required, maxlength etc.) never contain a hyphen.
+                    var type = v.indexOf('-') !== -1 ? 'custom' : 'native';
+
+                    // Custom instance exists
+                    if (meta[type] && meta[type].byKey(v + suffix)) {
+                        result[v] = meta[type].byKey(v + suffix);
+                    }
+                    // Default instance exists
+                    else if (meta[type] && meta[type].byKey(v)) {
+                        result[v] = meta[type].byKey(v);
+                    }
+                    // No instance at all, create one for custom validators.
+                    // (Instantiating native validators via iron-native validator wouldn't make sense here, since
+                    // they don't have messages by default and an instance will be present if message is supplied. )
+                    else if (type === 'custom' && (!meta[type] || !meta[type].byKey(v))) {
+                        result[v] = document.createElement(v);
+                    }
+                }, this);
+
+                return result;
             }
-        },
 
-        /**
-         * Creates an object with references to the validator instances supplied in validator property.
-         * @return {Object} validators The validators to be executed.
-         */
-        __computeValidator: function () {
-            var result = {};
-            var suffix = '--' + this.validatableId; // Suffix needed for specific instances of custom validators, overriding the default error message
-            var meta = Polymer.IronValidatableBehaviorMeta;
-            var validators = this.validator.replace(/\s+/g, ' ').split(' ');
+        };
 
-            validators.forEach(function (v) {
-                // Custom instance exists
-                if (meta && meta.byKey(v + suffix)) {
-                    result[v] = meta.byKey(v + suffix);
-                }
-                // Default instance exists
-                else if (meta && meta.byKey(v)) {
-                    result[v] = meta.byKey(v);
-                }
-                // No instance at all, create one
-                else if (!meta || !meta.byKey(v)) {
-                    result[v] = document.createElement(v);
-                }
-            });
-
-            return result;
-        }
-
-    };
+    }());
 
 </script>

--- a/iron-validatable-behavior.html
+++ b/iron-validatable-behavior.html
@@ -13,224 +13,225 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-    (function () {
+(function() {
 
-        /**
-         * Singleton IronMeta instances.
-         */
-        var customMeta = null;
-        var nativeMeta = null;
+  /**
+   * Singleton IronMeta instances.
+   */
+  var customMeta = null;
+  var nativeMeta = null;
 
-        /**
-         * `Use Polymer.IronValidatableBehavior` to implement an element that validates user input.
-         * Use the related `Polymer.IronValidatorBehavior` to add custom validation logic to an iron-input.
-         *
-         * By default, an `<iron-form>` element validates its fields when the user presses the submit button.
-         * To validate a form imperatively, call the form's `validate()` method, which in turn will
-         * call `validate()` on all its children. By using `Polymer.IronValidatableBehavior`, your
-         * custom element will get a public `validate()`, which
-         * will return the validity of the element, and a corresponding `invalid` attribute,
-         * which can be used for styling.
-         *
-         * To implement the custom validation logic of your element, you must override
-         * the protected `_getValidity()` method of this behaviour, rather than `validate()`.
-         * See [this](https://github.com/PolymerElements/iron-form/blob/master/demo/simple-element.html)
-         * for an example.
-         *
-         * ### Accessibility
-         *
-         * Changing the `invalid` property, either manually or by calling `validate()` will update the
-         * `aria-invalid` attribute.
-         *
-         * @demo demo/index.html
-         * @polymerBehavior
-         */
-        Polymer.IronValidatableBehavior = {
+  /**
+   * `Use Polymer.IronValidatableBehavior` to implement an element that validates user input.
+   * Use the related `Polymer.IronValidatorBehavior` to add custom validation logic to an iron-input.
+   *
+   * By default, an `<iron-form>` element validates its fields when the user presses the submit button.
+   * To validate a form imperatively, call the form's `validate()` method, which in turn will
+   * call `validate()` on all its children. By using `Polymer.IronValidatableBehavior`, your
+   * custom element will get a public `validate()`, which
+   * will return the validity of the element, and a corresponding `invalid` attribute,
+   * which can be used for styling.
+   *
+   * To implement the custom validation logic of your element, you must override
+   * the protected `_getValidity()` method of this behaviour, rather than `validate()`.
+   * See [this](https://github.com/PolymerElements/iron-form/blob/master/demo/simple-element.html)
+   * for an example.
+   *
+   * ### Accessibility
+   *
+   * Changing the `invalid` property, either manually or by calling `validate()` will update the
+   * `aria-invalid` attribute.
+   *
+   * @demo demo/index.html
+   * @polymerBehavior
+   */
+  Polymer.IronValidatableBehavior = {
 
-            properties: {
+    properties: {
 
-                /**
-                 * Name of the validator(s) to use.
-                 * Accepts a list of validators, separated by spaces.
-                 * Note that the order of the validators determines the priority of the error messages.
-                 */
-                validator: {
-                    type: String
-                },
+      /**
+       * Name of the validator(s) to use.
+       * Accepts a list of validators, separated by spaces.
+       * Note that the order of the validators determines the priority of the error messages.
+       */
+      validator: {
+        type: String
+      },
 
-                /**
-                 * True if the last call to `validate` is invalid.
-                 */
-                invalid: {
-                    notify: true,
-                    reflectToAttribute: true,
-                    type: Boolean,
-                    value: false
-                },
+      /**
+       * True if the last call to `validate` is invalid.
+       */
+      invalid: {
+        notify: true,
+        reflectToAttribute: true,
+        type: Boolean,
+        value: false
+      },
 
-                /**
-                 * This property is deprecated and should not be used. Use the global
-                 * validator meta singleton, `Polymer.IronValidatableBehaviorMeta` instead.
-                 */
-                _validatorMeta: {
-                    type: Object
-                },
+      /**
+       * This property is deprecated and should not be used. Use the global
+       * validator meta singleton, `Polymer.IronValidatableBehaviorMeta` instead.
+       */
+      _validatorMeta: {
+        type: Object
+      },
 
-                /**
-                 * Namespace for this validator. This property is deprecated and should
-                 * not be used. For all intents and purposes, please consider it a
-                 * read-only, config-time property.
-                 */
-                validatorType: {
-                    type: String,
-                    value: 'validator'
-                },
+      /**
+       * Namespace for this validator. This property is deprecated and should
+       * not be used. For all intents and purposes, please consider it a
+       * read-only, config-time property.
+       */
+      validatorType: {
+        type: String,
+        value: 'validator'
+      },
 
-                _validator: {
-                    type: Object,
-                    computed: '__computeValidator(validator)'
-                },
+      _validator: {
+        type: Object,
+        computed: '__computeValidator(validator)'
+      },
 
-                /**
-                 * Array holding error objects for the current state of the validatable element.
-                 * Each error has the following format:
-                 * {Object} error
-                 * {string} error.name -- validator name of custom validator instance with IronValidatorBehavior
-                 * {string} error.message -- message that is assigned to the validator instance
-                 * {number} error.priority -- priority of the error message, based on order supplied in validator property
-                 */
-                errors: {
-                    type: Array,
-                    readOnly: true,
-                    notify: true,
-                    value: function () {
-                        return [];
-                    }
-                },
+      /**
+       * Array holding error objects for the current state of the validatable element.
+       * Each error has the following keys:
+       * <ul>
+       * <li><b>validator</b> (String) : name of custom validator instance with IronValidatorBehavior</li>
+       * <li><b>message</b> (String) : message that is assigned to the validator instance</li>
+       * <li><b>priority</b> (Number) : priority of the error message, based on order supplied in validator property</li>
+       * </ul>
+       */
+      errors: {
+        type: Array,
+        readOnly: true,
+        notify: true,
+        value: function() {
+          return [];
+        }
+      },
 
-                /**
-                 * The id used to connect the validator instance implementing IronValidatableBehavior(having a 'for' property)
-                 * to the validatable. This is useful for validator instances containing custom messages.
-                 */
-                validatableId: {
-                    type: String,
-                    value: ''
-                }
+      /**
+       * The id used to connect the validator instance implementing IronValidatableBehavior(having a 'for' property)
+       * to the validatable. This is useful for validator instances containing custom messages.
+       */
+      validatableId: {
+        type: String,
+        value: ''
+      }
 
-            },
+    },
 
-            observers: [
-                '_invalidChanged(invalid)'
-            ],
+    observers: [
+      '_invalidChanged(invalid)'
+    ],
 
-            registered: function () {
-                customMeta = new Polymer.IronMeta({type: 'validator'});
-                nativeMeta = new Polymer.IronMeta({type: 'native-validator'});
-            },
+    registered: function() {
+      customMeta = new Polymer.IronMeta({type: 'validator'});
+      nativeMeta = new Polymer.IronMeta({type: 'native-validator'});
+    },
 
-            _invalidChanged: function () {
-                if (this.invalid) {
-                    this.setAttribute('aria-invalid', 'true');
-                } else {
-                    this.removeAttribute('aria-invalid');
-                }
-            },
+    _invalidChanged: function() {
+      if (this.invalid) {
+        this.setAttribute('aria-invalid', 'true');
+      } else {
+        this.removeAttribute('aria-invalid');
+      }
+    },
 
-            /**
-             * @return {boolean} True if the validator `validator` exists.
-             */
-            hasValidator: function () {
-                return this._validator != null;
-            },
+    /**
+     * @return {boolean} True if the validator `validator` exists.
+     */
+    hasValidator: function() {
+      return this._validator != null;
+    },
 
-            /**
-             * Returns true if the `value` is valid, and updates `invalid`. If you want
-             * your element to have custom validation logic, do not override this method;
-             * override `_getValidity(value)` instead.
+    /**
+     * Returns true if the `value` is valid, and updates `invalid`. If you want
+     * your element to have custom validation logic, do not override this method;
+     * override `_getValidity(value)` instead.
 
-             * @param {Object} value The value to be validated. By default, it is passed
-             * to the validator's `validate()` function, if a validator is set.
-             * @return {boolean} True if `value` is valid.
-             */
-            validate: function (value) {
-                this.invalid = !this._getValidity(value);
-                return !this.invalid;
-            },
+     * @param {Object} value The value to be validated. By default, it is passed
+     * to the validator's `validate()` function, if a validator is set.
+     * @return {boolean} True if `value` is valid.
+     */
+    validate: function(value) {
+      this.invalid = !this._getValidity(value);
+      return !this.invalid;
+    },
 
-            /**
-             * Returns true if `value` is valid.  By default, it is passed
-             * to the validator's `validate()` function, if a validator is set. You
-             * should override this method if you want to implement custom validity
-             * logic for your element.
-             *
-             * @param {Object} value The value to be validated
-             * @return {boolean} True if `value` is valid.
-             */
-            _getValidity: function (value) {
-                this._fillErrorArray(value);
-                return this.errors.length === 0;
-            },
+    /**
+     * Returns true if `value` is valid.  By default, it is passed
+     * to the validator's `validate()` function, if a validator is set. You
+     * should override this method if you want to implement custom validity
+     * logic for your element.
+     *
+     * @param {Object} value The value to be validated.
+     * @return {boolean} True if `value` is valid.
+     */
+    _getValidity: function(value) {
+      this._fillErrorArray(value);
+      return this.errors.length === 0;
+    },
 
-            /**
-             * Fills the errors property with objects as described in errors documentation.
-             * @param {Object} value The value to be validated.
-             */
-            _fillErrorArray: function (value) {
-                var index = 0;
-                this._setErrors([]);
+    /**
+     * Fills the errors property with objects as described in errors documentation.
+     * @param {Object} value The value to be validated.
+     */
+    _fillErrorArray: function(value) {
+      var index = 0;
+      this._setErrors([]);
 
-                // Fill error array that is prioritized based on order of arguments in validator attribute
-                for (var v in this._validator) {
-                    if (!this._validator[v].validate(value, this)) {
-                        this.push('errors', {
-                            name: this._validator[v].validatorName,
-                            message: this._validator[v].message,
-                            priority: index
-                        });
-                        index++;
-                    }
-                }
-            },
+      // Fill error array that is prioritized based on order of arguments in validator attribute
+      for (var v in this._validator) {
+        if (!this._validator[v].validate(value, this)) {
+          this.push('errors', {
+            validator: this._validator[v].validatorName,
+            message: this._validator[v].message,
+            priority: index
+          });
+          index++;
+        }
+      }
+    },
 
-            /**
-             * Creates an object with multiple validators.
-             *
-             * @return {Object} validators The validators to be executed.
-             */
-            __computeValidator: function () {
-                var result = {};
-                var suffix = '--' + this.validatableId; // Suffix needed for specific instances of custom validators, overriding the default error message
-                var validators = this.validator.replace(/\s+/g, ' ').split(' ');
+    /**
+     * Creates an object with multiple validators.
+     *
+     * @return {Object} validators The validators to be executed.
+     */
+    __computeValidator: function() {
+      var result = {};
+      var suffix = '--' + this.validatableId; // Suffix needed for specific instances of custom validators, overriding the default error message
+      var validators = this.validator.replace(/\s+/g, ' ').split(' ');
 
-                // Gather all meta information from custom and native validators
-                var meta = {custom: customMeta, native: nativeMeta};
+      // Gather all meta information from custom and native validators
+      var meta = {custom: customMeta, native: nativeMeta};
 
-                validators.forEach(function (v) {
-                    // Custom validators need to be web components and will therefore always contain a hyphen.
-                    // Native validators (think of required, maxlength etc.) never contain a hyphen.
-                    var type = v.indexOf('-') !== -1 ? 'custom' : 'native';
+      validators.forEach(function(v) {
+        // Custom validators need to be web components and will therefore always contain a hyphen.
+        // Native validators (think of required, maxlength etc.) never contain a hyphen.
+        var type = v.indexOf('-') !== -1 ? 'custom' : 'native';
 
-                    // Custom instance exists
-                    if (meta[type] && meta[type].byKey(v + suffix)) {
-                        result[v] = meta[type].byKey(v + suffix);
-                    }
-                    // Default instance exists
-                    else if (meta[type] && meta[type].byKey(v)) {
-                        result[v] = meta[type].byKey(v);
-                    }
-                    // No instance at all, create one for custom validators.
-                    // (Instantiating native validators via iron-native validator wouldn't make sense here, since
-                    // they don't have messages by default and an instance will be present if message is supplied. )
-                    else if (type === 'custom' && (!meta[type] || !meta[type].byKey(v))) {
-                        result[v] = document.createElement(v);
-                    }
-                }, this);
+        // Custom instance exists
+        if (meta[type] && meta[type].byKey(v + suffix)) {
+          result[v] = meta[type].byKey(v + suffix);
+        }
+        // Default instance exists
+        else if (meta[type] && meta[type].byKey(v)) {
+          result[v] = meta[type].byKey(v);
+        }
+        // No instance at all, create one for custom validators.
+        // (Instantiating native validators via iron-native validator wouldn't make sense here, since
+        // they don't have messages by default and an instance will be present if message is supplied. )
+        else if (type === 'custom' && (!meta[type] || !meta[type].byKey(v))) {
+          result[v] = document.createElement(v);
+        }
+      }, this);
 
-                return result;
-            }
+      return result;
+    }
 
-        };
+  };
 
-    }());
+ }());
 
 </script>

--- a/test/index.html
+++ b/test/index.html
@@ -23,7 +23,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /* no tests */
       WCT.loadSuites([
         'iron-validatable-behavior.html',
-        'iron-validatable-behavior.html?dom=shadow'
+        'iron-validatable-behavior-automatic-instances.html',
+        'iron-validatable-behavior.html?dom=shadow',
+        'iron-validatable-behavior-automatic-instances.html?dom=shadow'
       ]);
     </script>
 

--- a/test/iron-validatable-behavior-automatic-instances.html
+++ b/test/iron-validatable-behavior-automatic-instances.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+
+    <title>iron-validatable-behavior tests</title>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+    <link rel="import" href="../../test-fixture/test-fixture.html">
+    <link rel="import" href="test-validatable.html">
+    <link rel="import" href="validators/cats-only.html">
+    <link rel="import" href="validators/dogs-only.html">
+
+    <link rel="import" href="../../iron-validatable-behavior/iron-validatable-behavior.html">
+    <link rel="import" href="../../iron-validator-behavior/iron-validator-behavior.html">
+
+</head>
+<body>
+
+
+<test-fixture id="automaticallyInstantiating">
+    <template>
+        <test-validatable validator="cats-only dogs-only"></test-validatable>
+    </template>
+</test-fixture>
+
+<script>
+
+    suite('automatic validator instantiating', function () {
+        test('creates validator instance when not already done by user', function () {
+            var validatable = fixture('automaticallyInstantiating');
+            validatable.value = 'catsNeitherDogs';
+            validatable.validate();
+            assert.equal(validatable.errors.length, 2);
+        });
+    });
+
+</script>
+
+</body>

--- a/test/iron-validatable-behavior.html
+++ b/test/iron-validatable-behavior.html
@@ -28,6 +28,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="validators/dogs-only.html">
   <link rel="import" href="validators/no-cats.html">
   <link rel="import" href="validators/no-catfishes.html">
+  <link rel="import" href="../../iron-validator-behavior/iron-native-validator.html">
+  <link rel="import" href="../../iron-input/iron-input.html">
+  <link rel="import" href="native-validators-config.html">
 
 </head>
 <body>
@@ -58,6 +61,49 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <no-cats for="customCats" message="custom cats"></no-cats>
       <test-validatable validator="no-cats" validatable-id="customCats"></test-validatable>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="native-basic">
+    <template>
+      <native-validators-config></native-validators-config>
+      <input is="iron-input" validator="required cats-only dogs-only" required>
+      <input is="iron-input" validator="min step" min="5" step="22" type="number" value="3">
+    </template>
+  </test-fixture>
+
+  <test-fixture id="native-all">
+    <template>
+      <div>
+        <!-- since maxlength and minlength don't seem to trigger validity api, they are excluded below-->
+        <native-validators-config></native-validators-config>
+        <input is="iron-input" validator="required" required value="">
+        <input is="iron-input" validator="max" max="100" type="number" value="200">
+        <input is="iron-input" validator="min" min="50" type="number" value="25">
+        <input is="iron-input" validator="emailtype" type="email" value="nonsense">
+        <input is="iron-input" validator="urltype" type="url" value="nonsense">
+        <input is="iron-input" validator="step" step="3" type="number" value="2" wrong-value="1">
+        <input is="iron-input" validator="pattern" pattern="[A-Za-z]{3}" value="nonsense">
+      </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="override-native-validity-api">
+    <template>
+      <div>
+        <native-validators-config></native-validators-config>
+        <input is="iron-input" validator="maxlength" maxlength="3" value="1" wrong-value="four">
+        <input is="iron-input" validator="minlength" minlength="2" value="" wrong-value="1">
+      </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="override-native-messages">
+    <template>
+      <div>
+        <iron-native-validator validator-name="min" message="customMin" for="cm"></iron-native-validator>
+        <input is="iron-input" validator="min" type="number" min="10" value="9" validatable-id="cm">
+      </div>
     </template>
   </test-fixture>
 
@@ -159,6 +205,88 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         validatable.validate('cats');
         assert.equal(validatable.errors[0].message, 'custom cats');
       });
+
+    });
+
+    suite('native validators', function() {
+
+      test('native validator can be mixed with custom validators', function() {
+        var validatable = fixture('native-basic')[1];
+        validatable.value = '';
+        validatable.validate();
+
+        assert.equal(validatable.errors[0].name, 'required');
+        assert.equal(validatable.errors[0].priority, 0);
+
+        assert.equal(validatable.errors[1].name, 'cats-only');
+        assert.equal(validatable.errors[1].priority, 1);
+
+        assert.equal(validatable.errors[2].name, 'dogs-only');
+        assert.equal(validatable.errors[2].priority, 2);
+      });
+
+      test('native validators can be combined', function() {
+        var validatable = fixture('native-basic')[2];
+        validatable.value = '2';
+        validatable.validate();
+
+        assert.equal(validatable.errors[0].name, 'min');
+        assert.equal(validatable.errors[0].priority, 0);
+        assert.equal(validatable.errors[1].name, 'step');
+        assert.equal(validatable.errors[1].priority, 1);
+      });
+
+      test('native validators can contain custom messages', function() {
+        var validatable = fixture('override-native-messages').querySelector('[min]');
+        validatable.validate();
+
+        assert.equal(validatable.errors[0].name, 'min');
+        assert.equal(validatable.errors[0].message, 'customMin');
+      });
+
+      suite('all native validations(including messages), one by one', function() {
+
+        var mapping;
+        setup(function() {
+          mapping = fixture('native-all').querySelector('native-validators-config').messages;
+        });
+
+        test('validation works and message is set properly', function() {
+          Object.keys(mapping).forEach(function(validator) {
+            var validatable = fixture('native-all').querySelector('[validator="' + validator + '"]');
+            if(!validatable) {
+              return;
+            } // maxlength and minlength validity don't seem to be supported right now in FF? Testing in wct chrome seems not to work either
+
+            var msg = mapping[validator];
+            if(validatable.getAttribute('wrong-value'))
+              validatable.value = validatable.getAttribute('wrong-value');
+
+            validatable.validate();
+
+            assert.equal(validatable.errors[0].name, validator, 'Validator [' + validator + '] is not triggered');
+            assert.equal(validatable.errors[0].message, msg, 'Validation message for validator [' + validator + '] is not set properly');
+          });
+        });
+
+        test('validity API can be overridden', function() {
+          Object.keys(mapping).forEach(function(validator) {
+            var validatable = fixture('override-native-validity-api').querySelector('[validator="' + validator + '"]');
+            if(!validatable) return; // maxlength and minlength only present in fixture, ignore the rest
+
+            var msg = mapping[validator];
+            if(validatable.getAttribute('wrong-value'))
+              validatable.value = validatable.getAttribute('wrong-value');
+
+            validatable.validate();
+
+            assert.equal(validatable.errors[0].name, validator, 'Validator [' + validator + '] is not triggered');
+            assert.equal(validatable.errors[0].message, msg, 'Validation message for validator [' + validator + '] is not set properly');
+          });
+        });
+
+      });
+
 
     });
 

--- a/test/iron-validatable-behavior.html
+++ b/test/iron-validatable-behavior.html
@@ -24,8 +24,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="test-validatable.html">
-  <link rel="import" href="cats-only.html">
-  <link rel="import" href="dogs-only.html">
+  <link rel="import" href="validators/cats-only.html">
+  <link rel="import" href="validators/dogs-only.html">
+  <link rel="import" href="validators/no-cats.html">
+  <link rel="import" href="validators/no-catfishes.html">
 
 </head>
 <body>
@@ -41,6 +43,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <cats-only></cats-only>
       <dogs-only></dogs-only>
       <test-validatable></test-validatable>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="multipleValidators">
+    <template>
+      <no-cats></no-cats>
+      <no-catfishes></no-catfishes>
+      <test-validatable validator="no-cats no-catfishes"></test-validatable>
     </template>
   </test-fixture>
 
@@ -79,6 +89,62 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         input.validator = 'dogs-only';
         assert.isFalse(input.validate('cats'));
         assert.isTrue(input.validate('dogs'));
+      });
+
+    });
+
+    suite('multiple validators', function() {
+
+      test('adds multiple validators as an object with validator references', function() {
+        var validatable = fixture('multipleValidators')[2];
+        assert.equal(Object.keys(validatable._validator).length, 2);
+        assert.equal(Object.keys(validatable._validator)[0], 'no-cats');
+        assert.equal(Object.keys(validatable._validator)[1], 'no-catfishes');
+      });
+
+      test('uses functionality of added validators', function() {
+        var node = fixture('multipleValidators');
+        sinon.spy(node[0], 'validate');
+        sinon.spy(node[1], 'validate');
+        node[2].validate();
+        assert(node[0].validate.called);
+        assert(node[1].validate.called);
+      });
+
+      test('valid when all validators valid', function() {
+        var validatable = fixture('multipleValidators')[2];
+        validatable.validate('');
+        assert.equal(validatable.invalid, false);
+      });
+
+      test('invalid when one validator invalid', function() {
+        var validatable = fixture('multipleValidators')[2];
+        validatable.validate('catfish');
+        assert.equal(validatable.invalid, true);
+        assert.equal(validatable.errors.length, 1);
+      });
+
+    });
+
+    suite('error messages', function() {
+
+      test('adds an error array with objects containing names, messages and priorities', function() {
+        var validatable = fixture('multipleValidators')[2];
+        validatable.validate('cat');
+        assert.equal(validatable.errors.length, 2);
+        assert.equal(validatable.errors[0].name, 'no-cats');
+        assert.equal(validatable.errors[0].message, 'No cat(s) allowed');
+        assert.equal(validatable.errors[0].priority, 0);
+        assert.equal(validatable.errors[1].name, 'no-catfishes');
+        assert.equal(validatable.errors[1].message, 'No cat(fish(es)) allowed');
+        assert.equal(validatable.errors[1].priority, 1);
+      });
+
+      test('uses validator order for prioritizing messages', function() {
+        var validatable = fixture('multipleValidators')[2];
+        validatable.validate('cat');
+        assert.equal(validatable.errors[0].priority, 0);
+        assert.equal(validatable.errors[1].priority, 1);
       });
 
     });

--- a/test/iron-validatable-behavior.html
+++ b/test/iron-validatable-behavior.html
@@ -54,6 +54,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="customErrorMessages">
+    <template>
+      <no-cats for="customCats" message="custom cats"></no-cats>
+      <test-validatable validator="no-cats" validatable-id="customCats"></test-validatable>
+    </template>
+  </test-fixture>
+
   <script>
 
     suite('basic', function() {
@@ -145,6 +152,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         validatable.validate('cat');
         assert.equal(validatable.errors[0].priority, 0);
         assert.equal(validatable.errors[1].priority, 1);
+      });
+
+      test('adds custom error messages', function() {
+        var validatable = fixture('customErrorMessages')[1];
+        validatable.validate('cats');
+        assert.equal(validatable.errors[0].message, 'custom cats');
       });
 
     });

--- a/test/iron-validatable-behavior.html
+++ b/test/iron-validatable-behavior.html
@@ -185,10 +185,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var validatable = fixture('multipleValidators')[2];
         validatable.validate('cat');
         assert.equal(validatable.errors.length, 2);
-        assert.equal(validatable.errors[0].name, 'no-cats');
+        assert.equal(validatable.errors[0].validator, 'no-cats');
         assert.equal(validatable.errors[0].message, 'No cat(s) allowed');
         assert.equal(validatable.errors[0].priority, 0);
-        assert.equal(validatable.errors[1].name, 'no-catfishes');
+        assert.equal(validatable.errors[1].validator, 'no-catfishes');
         assert.equal(validatable.errors[1].message, 'No cat(fish(es)) allowed');
         assert.equal(validatable.errors[1].priority, 1);
       });
@@ -215,13 +215,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         validatable.value = '';
         validatable.validate();
 
-        assert.equal(validatable.errors[0].name, 'required');
+        assert.equal(validatable.errors[0].validator, 'required');
         assert.equal(validatable.errors[0].priority, 0);
 
-        assert.equal(validatable.errors[1].name, 'cats-only');
+        assert.equal(validatable.errors[1].validator, 'cats-only');
         assert.equal(validatable.errors[1].priority, 1);
 
-        assert.equal(validatable.errors[2].name, 'dogs-only');
+        assert.equal(validatable.errors[2].validator, 'dogs-only');
         assert.equal(validatable.errors[2].priority, 2);
       });
 
@@ -230,9 +230,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         validatable.value = '2';
         validatable.validate();
 
-        assert.equal(validatable.errors[0].name, 'min');
+        assert.equal(validatable.errors[0].validator, 'min');
         assert.equal(validatable.errors[0].priority, 0);
-        assert.equal(validatable.errors[1].name, 'step');
+        assert.equal(validatable.errors[1].validator, 'step');
         assert.equal(validatable.errors[1].priority, 1);
       });
 
@@ -240,7 +240,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var validatable = fixture('override-native-messages').querySelector('[min]');
         validatable.validate();
 
-        assert.equal(validatable.errors[0].name, 'min');
+        assert.equal(validatable.errors[0].validator, 'min');
         assert.equal(validatable.errors[0].message, 'customMin');
       });
 
@@ -264,7 +264,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             validatable.validate();
 
-            assert.equal(validatable.errors[0].name, validator, 'Validator [' + validator + '] is not triggered');
+            assert.equal(validatable.errors[0].validator, validator, 'Validator [' + validator + '] is not triggered');
             assert.equal(validatable.errors[0].message, msg, 'Validation message for validator [' + validator + '] is not set properly');
           });
         });
@@ -280,7 +280,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             validatable.validate();
 
-            assert.equal(validatable.errors[0].name, validator, 'Validator [' + validator + '] is not triggered');
+            assert.equal(validatable.errors[0].validator, validator, 'Validator [' + validator + '] is not triggered');
             assert.equal(validatable.errors[0].message, msg, 'Validation message for validator [' + validator + '] is not set properly');
           });
         });

--- a/test/native-validators-config.html
+++ b/test/native-validators-config.html
@@ -1,0 +1,64 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-validator-behavior/iron-native-validator.html">
+
+
+<!--Register all native validators with a custom message-->
+
+<dom-module id="native-validators-config">
+
+    <template>
+
+        <iron-native-validator validator-name="required" message="[[messages.required]]" id="instance"></iron-native-validator>
+        <iron-native-validator validator-name="max" message="[[messages.max]]"></iron-native-validator>
+        <iron-native-validator validator-name="min" message="[[messages.min]]"></iron-native-validator>
+        <iron-native-validator validator-name="step" message="[[messages.step]]"></iron-native-validator>
+        <iron-native-validator validator-name="maxlength" message="[[messages.maxlength]]"></iron-native-validator>
+        <iron-native-validator validator-name="minlength" message="[[messages.minlength]]"></iron-native-validator>
+        <iron-native-validator validator-name="pattern" message="[[messages.pattern]]"></iron-native-validator>
+        <iron-native-validator validator-name="emailtype" message="[[messages.emailtype]]"></iron-native-validator>
+        <iron-native-validator validator-name="urltype" message="[[messages.urltype]]"></iron-native-validator>
+
+    </template>
+
+    <script>
+
+        Polymer({
+
+            is: 'native-validators-config',
+
+            properties: {
+                messages: {
+                    type: Object,
+                    value: function () {
+                        return {
+                            required: 'value missing',
+                            max: 'less',
+                            min: 'more',
+                            step: 'step',
+                            maxlength: 'shorter',
+                            minlength: 'longer',
+                            pattern: 'either regex or input invalid',
+                            emailtype: 'no valid e-mail',
+                            urltype: 'no valid url'
+                        }
+                    }
+
+                }
+            },
+
+            ready: function() {
+                // Overriding via one instance, will set the method for every instance
+                this.$.instance.overrideValidationMethod('minlength', function(value, input) {
+                    var minlength = input.getAttribute('minlength');
+                    return value == '' || !minlength || value.length >= minlength;
+                });
+                this.$.instance.overrideValidationMethod('maxlength', function(value, input) {
+                    var maxlength = input.getAttribute('maxlength');
+                    return value == '' || !maxlength || value.length <= maxlength;
+                });
+            }
+        });
+
+    </script>
+
+</dom-module>

--- a/test/validators/cats-only.html
+++ b/test/validators/cats-only.html
@@ -8,7 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../../polymer/polymer.html">
 <link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
 
 <script>

--- a/test/validators/cats-only.html
+++ b/test/validators/cats-only.html
@@ -9,22 +9,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../iron-validator-behavior/iron-validator-behavior.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
 
 <script>
 
-  Polymer({
+    Polymer({
 
-    is: 'cats-only',
+        is: 'cats-only',
 
-    behaviors: [
-      Polymer.IronValidatorBehavior
-    ],
+        behaviors: [
+            Polymer.IronValidatorBehavior
+        ],
 
-    validate: function(value) {
-      return value === 'cats';
-    }
+        properties: {
+            message: {
+                type: String,
+                value: 'No cats'
+            }
+        },
 
-  });
+        validate: function (value) {
+            return value === 'cats';
+        }
+
+    });
 
 </script>

--- a/test/validators/dogs-only.html
+++ b/test/validators/dogs-only.html
@@ -8,7 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../../polymer/polymer.html">
 <link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
 
 <script>

--- a/test/validators/dogs-only.html
+++ b/test/validators/dogs-only.html
@@ -9,22 +9,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../iron-validator-behavior/iron-validator-behavior.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
 
 <script>
 
-  Polymer({
+    Polymer({
 
-    is: 'dogs-only',
+        is: 'dogs-only',
 
-    behaviors: [
-      Polymer.IronValidatorBehavior
-    ],
+        behaviors: [
+            Polymer.IronValidatorBehavior
+        ],
 
-    validate: function(value) {
-      return value === 'dogs';
-    }
+        properties: {
+            message: {
+                type: String,
+                value: 'No dogs'
+            }
+        },
 
-  });
+        validate: function (value) {
+            return value === 'dogs';
+        }
+
+    });
 
 </script>

--- a/test/validators/no-catfishes.html
+++ b/test/validators/no-catfishes.html
@@ -1,0 +1,37 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
+
+<script>
+
+    Polymer({
+
+        is: 'no-catfishes',
+
+        properties: {
+            message: {
+                type: String,
+                value: 'No cat(fish(es)) allowed'
+            }
+        },
+
+        behaviors: [
+            Polymer.IronValidatorBehavior
+        ],
+
+        validate: function (value) {
+            return !value || !value.match(/cat(fish|fishes)?$/);
+        }
+
+    });
+
+</script>

--- a/test/validators/no-cats.html
+++ b/test/validators/no-cats.html
@@ -1,0 +1,37 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../iron-validator-behavior/iron-validator-behavior.html">
+
+<script>
+
+    Polymer({
+
+        is: 'no-cats',
+
+        properties: {
+            message: {
+                type: String,
+                value: 'No cat(s) allowed'
+            }
+        },
+
+        behaviors: [
+            Polymer.IronValidatorBehavior
+        ],
+
+        validate: function (value) {
+            return !value || !value.match(/cats?$/);
+        }
+
+    });
+
+</script>


### PR DESCRIPTION
Currently, it's not possible to use multiple validators on an input.

Also see:
- https://github.com/PolymerElements/paper-input/issues/289
- https://github.com/PolymerElements/iron-input/issues/53

With this pull request, it will become possible to add multiple validators to elements implementing the validatable behavior, without having to write a new custom validator that combines functionality of other validators. 

Along with this functionality, the following will be supported:
- custom messages: 
  - stored in validators (so there's a single source of truth, resulting in consistency between forms and less development work)
  - support for multiple error messages, ordered by priority (the most important message will be shown by the paper-input)
- support for native validators('required', 'max', 'min', 'step', 'maxlength', 'minlength', 'pattern', 'emailtype'(type=email) and 'urltype' (type=url))
- automatic instantiating of custom validators 
- possibility to connect unique instances of a validator to a validatable-element (when overriding of the default message will be needed)

Everything is tested for backwards compatibility. All tests have run in chrome 51, firefox 46, OS X 10.9 safari 7, OS X 10.10 safari 8, OS X 10.11 safari 9, Windows 7 IE 10, Windows 8.1 IE 11, Windows 10 microsoftedge, Android 4.3, Android 4.4, Android 5, Android 6, iOS 7, iOS 8, iOS 9.3.

Note that, since the validation functionality is located in different repositories, the above functionality will contain pull requests in the following repositories:
- <a href="https://github.com/PolymerElements/iron-validator-behavior/pull/24">iron-validator-behavior</a>
- <a href="https://github.com/PolymerElements/iron-validatable-behavior/pull/28">iron-validable-behavior</a>
- <a href="https://github.com/PolymerElements/iron-input/pull/90">iron-input</a>
- <a href="https://github.com/PolymerElements/paper-input/pull/436">paper-input</a>

The link below shows an example of what would be the benefit of the old vs. the new situation.
It makes clear what the API will look like and how little code will be needed to achieve the same in the new situation.

https://tlouisse.github.io/iron-validatable-behavior/components/iron-validatable-behavior/demo/
