### PR TITLE
port to 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-bower_components
+bower_components*
+bower-*.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,14 @@ sudo: required
 before_script:
   - npm install -g bower polymer-cli@next
   - polymer install --variants
+  - sudo mv /usr/bin/google-chrome /usr/bin/google-chrome-old
+  - sudo mv /usr/bin/google-chrome-beta /usr/bin/google-chrome
 env:
   global:
-    - secure: kwLs1FMf/hBnbxItbOJzbIdGtPDK2R2dngleJPgXLW9ExzpGHPgOmWsvxWL2BzlxlzZgzwpmUhnnJdxHlo8AZtQl1uq6NWl/e3oj9oeenFugF60eIcd01ak4QmhBsk3/20O426QQsz2WckGZRGcudBz5Zj2it3t5cbH3pAi90jo=
-    - secure: hGl3bsjz9dbKTA/bAgfdrFMlT6VawxFljIPqX6zJD556jhpYxtkno278eIW8uLlIGC5nXRTWXQzWrRhN8i9osnqw1RFhW8C9lH+TLHEkYMvDnEOp9sZ8Amv6j8FdNibcDP8IPTo2PmIRwBK1nFp0VqhcQu/Eq7WUFolSns9E27k=
+    - secure: >-
+        kwLs1FMf/hBnbxItbOJzbIdGtPDK2R2dngleJPgXLW9ExzpGHPgOmWsvxWL2BzlxlzZgzwpmUhnnJdxHlo8AZtQl1uq6NWl/e3oj9oeenFugF60eIcd01ak4QmhBsk3/20O426QQsz2WckGZRGcudBz5Zj2it3t5cbH3pAi90jo=
+    - secure: >-
+        hGl3bsjz9dbKTA/bAgfdrFMlT6VawxFljIPqX6zJD556jhpYxtkno278eIW8uLlIGC5nXRTWXQzWrRhN8i9osnqw1RFhW8C9lH+TLHEkYMvDnEOp9sZ8Amv6j8FdNibcDP8IPTo2PmIRwBK1nFp0VqhcQu/Eq7WUFolSns9E27k=
 node_js: stable
 addons:
   firefox: latest
@@ -14,9 +18,11 @@ addons:
     sources:
       - google-chrome
     packages:
-      - google-chrome-stable
+      - google-chrome-beta
   sauce_connect: true
 script:
   - xvfb-run polymer test
-  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s ''default''; fi'
+  - >-
+    if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s 'default';
+    fi
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,22 @@
 language: node_js
 sudo: required
 before_script:
-- npm install -g bower polylint web-component-tester
-- bower install
-- polylint
+  - npm install -g bower polymer-cli@next
+  - polymer install --variants
 env:
   global:
-  - secure: kwLs1FMf/hBnbxItbOJzbIdGtPDK2R2dngleJPgXLW9ExzpGHPgOmWsvxWL2BzlxlzZgzwpmUhnnJdxHlo8AZtQl1uq6NWl/e3oj9oeenFugF60eIcd01ak4QmhBsk3/20O426QQsz2WckGZRGcudBz5Zj2it3t5cbH3pAi90jo=
-  - secure: hGl3bsjz9dbKTA/bAgfdrFMlT6VawxFljIPqX6zJD556jhpYxtkno278eIW8uLlIGC5nXRTWXQzWrRhN8i9osnqw1RFhW8C9lH+TLHEkYMvDnEOp9sZ8Amv6j8FdNibcDP8IPTo2PmIRwBK1nFp0VqhcQu/Eq7WUFolSns9E27k=
+    - secure: kwLs1FMf/hBnbxItbOJzbIdGtPDK2R2dngleJPgXLW9ExzpGHPgOmWsvxWL2BzlxlzZgzwpmUhnnJdxHlo8AZtQl1uq6NWl/e3oj9oeenFugF60eIcd01ak4QmhBsk3/20O426QQsz2WckGZRGcudBz5Zj2it3t5cbH3pAi90jo=
+    - secure: hGl3bsjz9dbKTA/bAgfdrFMlT6VawxFljIPqX6zJD556jhpYxtkno278eIW8uLlIGC5nXRTWXQzWrRhN8i9osnqw1RFhW8C9lH+TLHEkYMvDnEOp9sZ8Amv6j8FdNibcDP8IPTo2PmIRwBK1nFp0VqhcQu/Eq7WUFolSns9E27k=
 node_js: stable
 addons:
   firefox: '46.0'
   apt:
     sources:
-    - google-chrome
+      - google-chrome
     packages:
-    - google-chrome-stable
+      - google-chrome-stable
   sauce_connect: true
 script:
-- xvfb-run wct
-- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'default'; fi
+  - xvfb-run polymer test
+  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s ''default''; fi'
 dist: trusty

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ thing! https://github.com/PolymerLabs/tedium/issues
 _[Demo and API docs](https://elements.polymer-project.org/elements/iron-validatable-behavior)_
 
 
-##Polymer.IronValidatableBehavior
+## Polymer.IronValidatableBehavior
 
 `Use Polymer.IronValidatableBehavior` to implement an element that validates user input.
 Use the related `Polymer.IronValidatorBehavior` to add custom validation logic to an iron-input.
@@ -33,6 +33,10 @@ To implement the custom validation logic of your element, you must override
 the protected `_getValidity()` method of this behaviour, rather than `validate()`.
 See [this](https://github.com/PolymerElements/iron-form/blob/master/demo/simple-element.html)
 for an example.
+
+### Changes in 2.0
+- `validate()` no longer requires a `value` paramer to be passed, and will use the element's `value` property if it exists
+- `validatorType` and `validatorName` were unused and have been removed
 
 ### Accessibility
 

--- a/bower.json
+++ b/bower.json
@@ -27,10 +27,25 @@
     "iron-validator-behavior": "PolymerElements/iron-validator-behavior#2.0-preview",
     "paper-styles": "PolymerElements/paper-styles#2.0-preview",
     "test-fixture": "PolymerElements/test-fixture#^2.0.0",
-    "web-component-tester": "^4.0.0",
+    "web-component-tester": "v6.0.0-prerelease.5",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
   },
   "resolutions": {
     "test-fixture": "^2.0.0"
+  },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "iron-meta": "PolymerElements/iron-meta#^1.0.0",
+        "polymer": "Polymer/polymer#^1.1.0"
+      },
+      "devDependencies": {
+        "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
+        "iron-validator-behavior": "PolymerElements/iron-validator-behavior#^1.0.0",
+        "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+        "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+      }
+    }
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "ignore": [],
   "dependencies": {
     "iron-meta": "PolymerElements/iron-meta#2.0-preview",
-    "polymer": "Polymer/polymer#2.0-preview"
+    "polymer": "Polymer/polymer#^2.0.0-rc.1"
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",

--- a/bower.json
+++ b/bower.json
@@ -26,11 +26,11 @@
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
     "iron-validator-behavior": "PolymerElements/iron-validator-behavior#2.0-preview",
     "paper-styles": "PolymerElements/paper-styles#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
+    "test-fixture": "PolymerElements/test-fixture#^2.0.0",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
   },
   "resolutions": {
-    "test-fixture": "custom-elements-v1"
+    "test-fixture": "^2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "polymer": "Polymer/polymer#^2.0.0-rc.1"
   },
   "devDependencies": {
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
     "iron-validator-behavior": "PolymerElements/iron-validator-behavior#2.0-preview",
     "paper-styles": "PolymerElements/paper-styles#2.0-preview",
@@ -37,6 +38,7 @@
         "polymer": "Polymer/polymer#^1.1.0"
       },
       "devDependencies": {
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
         "iron-validator-behavior": "PolymerElements/iron-validator-behavior#^1.0.0",
         "paper-styles": "PolymerElements/paper-styles#^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -30,9 +30,6 @@
     "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.6",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1"
   },
-  "resolutions": {
-    "test-fixture": "^2.0.0"
-  },
   "variants": {
     "1.x": {
       "dependencies": {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-validatable-behavior",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Provides a behavior for an element that validates user input",
   "authors": "The Polymer Authors",
   "keywords": [

--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
         "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
         "iron-validator-behavior": "PolymerElements/iron-validator-behavior#^1.0.0",
-        "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+        "paper-styles": "PolymerElements/paper-styles#^1.0.4",
         "test-fixture": "PolymerElements/test-fixture#^1.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
         "web-component-tester": "^4.0.0"

--- a/bower.json
+++ b/bower.json
@@ -26,9 +26,9 @@
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
     "iron-validator-behavior": "PolymerElements/iron-validator-behavior#2.0-preview",
     "paper-styles": "PolymerElements/paper-styles#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#^2.0.0",
-    "web-component-tester": "v6.0.0-prerelease.5",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
+    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.6",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1"
   },
   "resolutions": {
     "test-fixture": "^2.0.0"
@@ -44,7 +44,8 @@
         "iron-validator-behavior": "PolymerElements/iron-validator-behavior#^1.0.0",
         "paper-styles": "PolymerElements/paper-styles#^1.0.0",
         "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+        "web-component-tester": "^4.0.0"
       }
     }
   }

--- a/bower.json
+++ b/bower.json
@@ -19,15 +19,18 @@
   "homepage": "https://github.com/PolymerElements/iron-validatable-behavior",
   "ignore": [],
   "dependencies": {
-    "iron-meta": "PolymerElements/iron-meta#^1.0.0",
-    "polymer": "Polymer/polymer#^1.0.0"
+    "iron-meta": "PolymerElements/iron-meta#2.0-preview",
+    "polymer": "Polymer/polymer#2.0-preview"
   },
   "devDependencies": {
-    "paper-styles": "PolymerElements/paper-styles#^1.0.4",
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-validator-behavior": "PolymerElements/iron-validator-behavior#^1.0.0",
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
+    "iron-validator-behavior": "PolymerElements/iron-validator-behavior#2.0-preview",
+    "paper-styles": "PolymerElements/paper-styles#2.0-preview",
+    "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
     "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
+  },
+  "resolutions": {
+    "test-fixture": "custom-elements-v1"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,53 +19,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-  <link rel="import" href="../../paper-styles/demo-pages.html">
+  <link rel="import" href="../../paper-styles/color.html">
+  <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
   <link rel="import" href="cats-only.html">
   <link rel="import" href="validatable-input.html">
-
-  <style is="custom-style">
-
-    .valid {
-      color: var(--google-green-500);
-    }
-
-    .invalid {
-      color: var(--google-red-500);
-    }
-
-  </style>
-
+  <custom-style>
+    <style is="custom-style" include="demo-pages-shared-styles"></style>
+  </custom-style>
 </head>
 <body>
-  <div class="vertical-section vertical-section-container centered">
-  <h1>&lt;iron-validatable-behavior&gt;</h1>
+  <div class="vertical-section-container centered">
+    <h3>The <code>cats-only</code> validator only accepts the string "cats"</h3>
+    <demo-snippet class="centered-demo">
+      <template>
+        <custom-style>
+          <style is="custom-style" include="demo-pages-shared-styles">
+            validatable-input:not([invalid]) {
+              border: 1px solid var(--google-green-500);
+              color: var(--google-green-500);
+            }
+            validatable-input[invalid] {
+              border: 1px solid var(--google-red-500);
+              color: var(--google-red-500);
+            }
+          </style>
+        </custom-style>
 
-  <template is="dom-bind">
-
-    <cats-only></cats-only>
-
-    <section>
-
-      <p>
-        only type <code>cats</code>:
-
-        <input is="validatable-input" invalid="{{invalid}}" validator="cats-only">
-
-        <span class="valid" hidden$="[[invalid]]">valid</span>
-        <span class="invalid" hidden$="[[!invalid]]">invalid</span>
-      </p>
-
-    </section>
-
-  </template>
-
+        <cats-only></cats-only>
+        <validatable-input validator="cats-only"></validatable-input>
+      </template>
+    </demo-snippet>
   </div>
-
-  <script>
-
-    document.querySelector('template[is="dom-bind"]').invalid = false;
-
-  </script>
-
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -35,7 +35,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template>
         <custom-style>
           <style is="custom-style" include="demo-pages-shared-styles">
-            validatable-input:not([invalid]) {
+            validatable-input {
               border: 1px solid var(--google-green-500);
               color: var(--google-green-500);
             }

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,7 +30,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
   <div class="vertical-section-container centered">
-    <h3>The <code>cats-only</code> validator only accepts the string "cats"</h3>
+    <h3>The <code>cats-only</code> validator only accepts the string "cats" and
+      its suffixes ("c", "ca", "cat").</h3>
     <demo-snippet class="centered-demo">
       <template>
         <custom-style>

--- a/demo/validatable-input.html
+++ b/demo/validatable-input.html
@@ -11,36 +11,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../iron-validatable-behavior.html">
 
-<script>
-
-  Polymer({
-
-    is: 'validatable-input',
-
-    extends: 'input',
-
-    properties: {
-
-      invalid: {
-        notify: true,
-        type: Boolean,
-        value: false
+<dom-module id="validatable-input">
+  <template>
+    <style>
+      :host {
+        display: inline-block;
       }
+      input {
+        padding: 0.4em;
+        font-size: 16px;
+        margin: 5px;
+        color: inherit;
+      }
+    </style>
+    <input id="input">
+  </template>
+  <script>
+    Polymer({
+      is: 'validatable-input',
+      properties: {
+        invalid: {
+          reflectToAttribute: true,
+          type: Boolean,
+          value: false
+        }
+      },
 
-    },
+      behaviors: [
+        Polymer.IronValidatableBehavior
+      ],
 
-    behaviors: [
-      Polymer.IronValidatableBehavior
-    ],
+      listeners: {
+        'input': '_onInput'
+      },
 
-    listeners: {
-      'input': '_onInput'
-    },
-
-    _onInput: function(event) {
-      this.invalid = !this.validate(event.target.value);
-    }
-
-  });
-
-</script>
+      _onInput: function() {
+        this.invalid = !this.validate(this.$.input.value);
+      }
+    });
+  </script>
+</dom-module>

--- a/iron-validatable-behavior.html
+++ b/iron-validatable-behavior.html
@@ -44,14 +44,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.IronValidatableBehavior = {
 
     properties: {
-
       /**
        * Name of the validator to use.
        */
       validator: {
         type: String
       },
-
+      
       /**
        * True if the last call to `validate` is invalid.
        */
@@ -114,12 +113,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * your element to have custom validation logic, do not override this method;
      * override `_getValidity(value)` instead.
 
-     * @param {Object} value The value to be validated. By default, it is passed
-     * to the validator's `validate()` function, if a validator is set.
+     * @param {Object} value Deprecated: The value to be validated. By default,
+     * it is passed to the validator's `validate()` function, if a validator is set.
+     * If this argument is not specified, then the element's `value` property
+     * is used, if it exists.
      * @return {boolean} True if `value` is valid.
      */
     validate: function(value) {
-      this.invalid = !this._getValidity(value);
+      // If this is an element that also has a value property, and there was
+      // no explicit value argument passed, use the element's property instead.
+      if (value === undefined && this.value !== undefined)
+        this.invalid = !this._getValidity(this.value);
+      else
+        this.invalid = !this._getValidity(value);
       return !this.invalid;
     },
 

--- a/iron-validatable-behavior.html
+++ b/iron-validatable-behavior.html
@@ -58,18 +58,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         notify: true,
         reflectToAttribute: true,
         type: Boolean,
-        value: false
+        value: false,
+        observer: '_invalidChanged'
       },
-
-      _validator: {
-        type: Object,
-        computed: '__computeValidator(validator)'
-      }
     },
-
-    observers: [
-      '_invalidChanged(invalid)'
-    ],
 
     registered: function() {
       Polymer.IronValidatableBehaviorMeta = new Polymer.IronMeta({type: 'validator'});
@@ -81,6 +73,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       } else {
         this.removeAttribute('aria-invalid');
       }
+    },
+
+    /* Recompute this every time it's needed, because we don't know if the
+     * underlying IronValidatableBehaviorMeta has changed. */
+    get _validator() {
+      return Polymer.IronValidatableBehaviorMeta &&
+          Polymer.IronValidatableBehaviorMeta.byKey(this.validator);
     },
 
     /**
@@ -126,11 +125,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return this._validator.validate(value);
       }
       return true;
-    },
-
-    __computeValidator: function(validator) {
-      return Polymer.IronValidatableBehaviorMeta &&
-          Polymer.IronValidatableBehaviorMeta.byKey(validator);
     }
   };
 

--- a/iron-validatable-behavior.html
+++ b/iron-validatable-behavior.html
@@ -50,7 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       validator: {
         type: String
       },
-      
+
       /**
        * True if the last call to `validate` is invalid.
        */
@@ -59,24 +59,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         reflectToAttribute: true,
         type: Boolean,
         value: false
-      },
-
-      /**
-       * This property is deprecated and should not be used. Use the global
-       * validator meta singleton, `Polymer.IronValidatableBehaviorMeta` instead.
-       */
-      _validatorMeta: {
-        type: Object
-      },
-
-      /**
-       * Namespace for this validator. This property is deprecated and should
-       * not be used. For all intents and purposes, please consider it a
-       * read-only, config-time property.
-       */
-      validatorType: {
-        type: String,
-        value: 'validator'
       },
 
       _validator: {
@@ -146,9 +128,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return true;
     },
 
-    __computeValidator: function() {
+    __computeValidator: function(validator) {
       return Polymer.IronValidatableBehaviorMeta &&
-          Polymer.IronValidatableBehaviorMeta.byKey(this.validator);
+          Polymer.IronValidatableBehaviorMeta.byKey(validator);
     }
   };
 

--- a/test/index.html
+++ b/test/index.html
@@ -24,7 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       /* no tests */
       WCT.loadSuites([
-        'iron-validatable-behavior.html?wc-shadydom=true&wc-register=true',
+        'iron-validatable-behavior.html?wc-shadydom=true&wc-ce=true',
         'iron-validatable-behavior.html?dom=shadow'
       ]);
     </script>

--- a/test/index.html
+++ b/test/index.html
@@ -6,7 +6,9 @@ The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
---><html><head>
+-->
+<html>
+<head>
 
     <title>iron-validatable-behavior tests</title>
 
@@ -27,6 +29,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ]);
     </script>
 
-  
-
-</body></html>
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -24,7 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       /* no tests */
       WCT.loadSuites([
-        'iron-validatable-behavior.html',
+        'iron-validatable-behavior.html?wc-shadydom=true&wc-register=true',
         'iron-validatable-behavior.html?dom=shadow'
       ]);
     </script>

--- a/test/test-validatable.html
+++ b/test/test-validatable.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="test-validatable">
   <template>
-    <content></content>
+    <slot></slot>
   </template>
 </dom-module>
 


### PR DESCRIPTION
DO NOT MERGE
- ⚠️ `_validator` used to be cached, and now it's recomputed every time it's accessed. This is because we can't control the ordering of `IronValidatableBehaviour` and `IronValidatorBehavior`, since it depends on the order of the imports (which is weird, see https://github.com/webcomponents/custom-elements/issues/15) (and for this to work, `IronValidatorBehavior` _needs_ to run first, so that the `validator` exists in `IronMeta` by the time `IronValidatableBehaviour`'s `validator` observer runs. I don't think this should be a giant perf hit, since `IronMeta` is basically just a map -- @cdata for a double check 
- added a fix for https://github.com/PolymerElements/iron-validatable-behavior/issues/27 (by using the element's `value` property, if it exists). Though, as `IronFormElementBehaviour` will be deprecated in 2.0 (since the `<form>` can no longer be a type extension and therefore can get its children without it), I wonder if we should add the `value` attribute instead here.
- removed some of the deprecated properties from the behaviour (i.e things that i think should have been private all along)
- updated the demo element from a type extension to a wrapper for an input
- updated the demo to use `demo-snippet` 
